### PR TITLE
Add Doctrine Metadata.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -31,10 +31,17 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $this->useMetadataCaching = $caching;
 
-        $this->timeStart   = microtime(true);
-        $this->memoryStart = memory_get_usage();
+        if (!$caching) {
+            $this->timeStart   = microtime(true);
+            $this->memoryStart = memory_get_usage();
+        }
 
         $this->setUp();
+
+        if ($caching) {
+            $this->timeStart   = microtime(true);
+            $this->memoryStart = memory_get_usage();
+        }
     }
 
     final public function getClass(): string

--- a/src/Provider/Doctrine.php
+++ b/src/Provider/Doctrine.php
@@ -12,12 +12,19 @@ class Doctrine extends AbstractProvider
 
     public function setUp()
     {
+        $proxyDir = sys_get_temp_dir() . '/Proxies';
+        $cache = new \Doctrine\Common\Cache\ArrayCache();
         $config = Setup::createAnnotationMetadataConfiguration(
             [DOCROOT . '/src/Models/Doctrine'],
-            false
+            false,
+            $proxyDir,
+            $cache
         );
 
         $this->em = EntityManager::create(require_once DOCROOT . '/config/doctrine.php', $config);
+
+        $metadatas = $this->em->getMetadataFactory()->getAllMetadata();
+        $this->em->getProxyFactory()->generateProxyClasses($metadatas, $proxyDir);
     }
 
     public function create()


### PR DESCRIPTION
Add Metadata cache for Doctrine, also when benchmarking with cache, then the setup should not be part of the benchmark.

Otherwise, between each iteration the setUp() would need to be re-done to lead to the same behaivour.